### PR TITLE
Ignore extra fallback URL

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -60,82 +60,6 @@ describe('Input Validation', () => {
     jest.resetAllMocks()
   })
 
-  it('Uses default API URL when api_url is empty', async () => {
-    // Mock the environment variable
-    const originalGitHubApiUrl = process.env.GITHUB_API_URL
-    process.env.GITHUB_API_URL = 'https://api.github.com'
-
-    core.getInput
-      .mockReturnValueOnce('add') // action
-      .mockReturnValueOnce('false') // create
-      .mockReturnValueOnce('token') // github_token
-      .mockReturnValueOnce(['test'].join('\n')) // labels
-      .mockReturnValueOnce('1') // issue_number
-      .mockReturnValueOnce('issue-ops/labeler') // repository
-      .mockReturnValueOnce('') // api_url (empty)
-
-    await main.run()
-
-    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: false })
-    expect(core.info).toHaveBeenCalledWith(
-      '  - API URL: https://api.github.com'
-    )
-
-    // Restore the original environment variable
-    if (originalGitHubApiUrl !== undefined) {
-      process.env.GITHUB_API_URL = originalGitHubApiUrl
-    } else {
-      delete process.env.GITHUB_API_URL
-    }
-  })
-
-  it('Uses GITHUB_API_URL environment variable when api_url is empty', async () => {
-    // Mock the environment variable to a different value
-    const originalGitHubApiUrl = process.env.GITHUB_API_URL
-    process.env.GITHUB_API_URL = 'https://github.enterprise.internal/api/v3'
-
-    core.getInput
-      .mockReturnValueOnce('add') // action
-      .mockReturnValueOnce('false') // create
-      .mockReturnValueOnce('token') // github_token
-      .mockReturnValueOnce(['test'].join('\n')) // labels
-      .mockReturnValueOnce('1') // issue_number
-      .mockReturnValueOnce('issue-ops/labeler') // repository
-      .mockReturnValueOnce('') // api_url (empty)
-
-    await main.run()
-
-    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: false })
-    expect(core.info).toHaveBeenCalledWith(
-      '  - API URL: https://github.enterprise.internal/api/v3'
-    )
-
-    // Restore the original environment variable
-    if (originalGitHubApiUrl !== undefined) {
-      process.env.GITHUB_API_URL = originalGitHubApiUrl
-    } else {
-      delete process.env.GITHUB_API_URL
-    }
-  })
-
-  it('Uses custom API URL when provided', async () => {
-    const customApiUrl = 'https://github.enterprise.com/api/v3'
-
-    core.getInput
-      .mockReturnValueOnce('add') // action
-      .mockReturnValueOnce('false') // create
-      .mockReturnValueOnce('token') // github_token
-      .mockReturnValueOnce(['test'].join('\n')) // labels
-      .mockReturnValueOnce('1') // issue_number
-      .mockReturnValueOnce('issue-ops/labeler') // repository
-      .mockReturnValueOnce(customApiUrl) // api_url
-
-    await main.run()
-
-    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: false })
-    expect(core.info).toHaveBeenCalledWith(`  - API URL: ${customApiUrl}`)
-  })
-
   it('Handles invalid issue number', async () => {
     core.getInput
       .mockReturnValueOnce('add') // action
@@ -189,7 +113,7 @@ describe('Add Labels', () => {
     expect(core.getInput).toHaveReturnedWith('1')
     expect(core.getInput).toHaveBeenCalledWith('repository', { required: true })
     expect(core.getInput).toHaveReturnedWith('issue-ops/labeler')
-    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: false })
+    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: true })
     expect(core.getInput).toHaveReturnedWith('')
   })
 
@@ -208,7 +132,7 @@ describe('Add Labels', () => {
 
     await main.run()
 
-    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: false })
+    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: true })
     expect(core.info).toHaveBeenCalledWith(
       '  - API URL: https://github.enterprise.com/api/v3'
     )

--- a/dist/index.js
+++ b/dist/index.js
@@ -30616,8 +30616,7 @@ async function run() {
     const repository = coreExports.getInput('repository', {
         required: true
     });
-    const apiUrl = coreExports.getInput('api_url', { required: false }) ||
-        `${process.env.GITHUB_API_URL}`;
+    const apiUrl = coreExports.getInput('api_url', { required: true });
     coreExports.info('Running action with the following inputs:');
     coreExports.info(`  - Action: ${action}`);
     coreExports.info(`  - Create: ${create}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "labeler",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "labeler",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labeler",
   "description": "Manage labels for issues and pull requests",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "homepage": "https://github.com/issue-ops/labeler#readme",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,9 +19,7 @@ export async function run(): Promise<void> {
   const repository: string = core.getInput('repository', {
     required: true
   })
-  const apiUrl: string =
-    core.getInput('api_url', { required: false }) ||
-    `${process.env.GITHUB_API_URL}`
+  const apiUrl: string = core.getInput('api_url', { required: true })
 
   core.info('Running action with the following inputs:')
   core.info(`  - Action: ${action}`)


### PR DESCRIPTION
The `process.env.GITHUB_API_URL` fallback is not required since the default is being set in the `action.yml`. They are effectively the same thing, since the GitHub context and environment variables come from the same source.